### PR TITLE
Implement data structure changes from new f2b

### DIFF
--- a/jail.go
+++ b/jail.go
@@ -60,6 +60,9 @@ func (conn *Conn) JailBanIP(jail string, ip string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if val, ok := fail2banOutput.(int64); ok {
+		return strconv.FormatInt(val, 10), nil
+	}
 	return fail2banOutput.(string), nil
 }
 
@@ -67,6 +70,9 @@ func (conn *Conn) JailUnbanIP(jail string, ip string) (string, error) {
 	fail2banOutput, err := conn.fail2banRequest([]string{"set", jail, "unbanip", ip})
 	if err != nil {
 		return "", err
+	}
+	if val, ok := fail2banOutput.(int64); ok {
+		return strconv.FormatInt(val, 10), nil
 	}
 	return fail2banOutput.(string), nil
 }
@@ -116,6 +122,7 @@ func (conn *Conn) JailSetUseDNS(jail string, useDNS string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return fail2banOutput.(string), nil
 }
 

--- a/jail.go
+++ b/jail.go
@@ -21,10 +21,10 @@ func (conn *Conn) JailStatus(jail string) (currentlyFailed int64, totalFailed in
 	fileList = interfaceSliceToStringSlice(filter.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
 	currentlyBanned = action.([]interface{})[0].(ogórek.Tuple)[1].(int64)
 	totalBanned = action.([]interface{})[1].(ogórek.Tuple)[1].(int64)
-	if val, ok := action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}); ok {
-		IPList = interfaceSliceToStringSlice(val)
-	} else {
+	if _, ok := action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{})[0].(ogórek.Call); ok {
 		IPList = callSliceToStringSlice(action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
+	} else {
+		IPList = interfaceSliceToStringSlice(action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
 	}
 
 	return

--- a/jail.go
+++ b/jail.go
@@ -21,7 +21,12 @@ func (conn *Conn) JailStatus(jail string) (currentlyFailed int64, totalFailed in
 	fileList = interfaceSliceToStringSlice(filter.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
 	currentlyBanned = action.([]interface{})[0].(ogórek.Tuple)[1].(int64)
 	totalBanned = action.([]interface{})[1].(ogórek.Tuple)[1].(int64)
-	IPList = callSliceToStringSlice(action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
+	if val, ok := action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}); ok {
+		IPList = interfaceSliceToStringSlice(val)
+	} else {
+		IPList = callSliceToStringSlice(action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
+	}
+
 	return
 }
 

--- a/jail.go
+++ b/jail.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strconv"
 
-	"github.com/kisielk/og-rek"
+	ogórek "github.com/kisielk/og-rek"
 )
 
 func (conn *Conn) JailStatus(jail string) (currentlyFailed int64, totalFailed int64, fileList []string, currentlyBanned int64, totalBanned int64, IPList []string, err error) {
@@ -21,7 +21,7 @@ func (conn *Conn) JailStatus(jail string) (currentlyFailed int64, totalFailed in
 	fileList = interfaceSliceToStringSlice(filter.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
 	currentlyBanned = action.([]interface{})[0].(ogórek.Tuple)[1].(int64)
 	totalBanned = action.([]interface{})[1].(ogórek.Tuple)[1].(int64)
-	IPList = interfaceSliceToStringSlice(action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
+	IPList = callSliceToStringSlice(action.([]interface{})[2].(ogórek.Tuple)[1].([]interface{}))
 	return
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,9 @@
 package fail2go
 
+import (
+	ogórek "github.com/kisielk/og-rek"
+)
+
 func interfaceSliceToStringSlice(interfaceSlice []interface{}) (stringSlice []string) {
 	for _, v := range interfaceSlice {
 		stringSlice = append(stringSlice, v.(string))
@@ -14,4 +18,11 @@ func stringInSliceIndex(input string, list []string) int {
 		}
 	}
 	return -1
+}
+
+func callSliceToStringSlice(callSlice []interface{}) (stringSlice []string) {
+	for _, v := range callSlice {
+		stringSlice = append(stringSlice, v.(ogórek.Call).Args[0].(string))
+	}
+	return
 }


### PR DESCRIPTION
With fresh fail2ban (tested on v0.10.5) fail2go fails with the following error:

```
fail2rest    | 2020/10/22 10:52:51 http: panic serving 192.168.112.1:43886: interface conversion: interface {} is ogórek.Call, not string
fail2rest    | goroutine 24 [running]:
fail2rest    | net/http.(*conn).serve.func1(0xc0001246e0)
fail2rest    | 	/usr/local/go/src/net/http/server.go:1795 +0x139
fail2rest    | panic(0x9a11c0, 0xc0001d80c0)
fail2rest    | 	/usr/local/go/src/runtime/panic.go:679 +0x1b2
fail2rest    | github.com/Sean-Der/fail2go.interfaceSliceToStringSlice(0xc00018eab0, 0x1, 0x1, 0xc00018eae0, 0x1, 0x1)
fail2rest    | 	/go/pkg/mod/github.com/!sean-!der/fail2go@v0.0.0-20170425205434-72ede0333ad6/utils.go:5 +0x16c
fail2rest    | github.com/Sean-Der/fail2go.(*Conn).JailStatus(0xc0000816c0, 0xc000099289, 0x4, 0xc000099289, 0x4, 0x1, 0xe63b20, 0x0, 0x0, 0x0, ...)
fail2rest    | 	/go/pkg/mod/github.com/!sean-!der/fail2go@v0.0.0-20170425205434-72ede0333ad6/jail.go:24 +0x38d
fail2rest    | github.com/UCCNetsoc/fail2rest/api.(*API).getJail(0xc00009a150, 0xade220, 0xc0001282a0, 0xc0000d9900)
fail2rest    | 	/fail2rest/api/jail.go:23 +0xf6
fail2rest    | net/http.HandlerFunc.ServeHTTP(0xc000081860, 0xade220, 0xc0001282a0, 0xc0000d9900)
fail2rest    | 	/usr/local/go/src/net/http/server.go:2036 +0x44
fail2rest    | github.com/go-chi/chi.(*Mux).routeHTTP(0xc00009d0e0, 0xade220, 0xc0001282a0, 0xc0000d9900)
```

This behavior caused by changes in the fail2ban data structure. I added needed parsing to the library.

Data sample:
```
//list of the banned IPs
spew.Dump(action.([]interface{})[2])

 (ogórek.Tuple) (len=2 cap=2) {
  (string) (len=14) "Banned IP list",
  ([]interface {}) (len=1 cap=2) {
   (ogórek.Call) {
    Callable: (ogórek.Class) {
     Module: (string) (len=11) "__builtin__",
     Name: (string) (len=3) "str"
    },
    Args: (ogórek.Tuple) (len=1 cap=1) {
     (string) (len=13) "89.1.1.1"
    }
   },
   (ogórek.Call) {
    Callable: (ogórek.Class) {
     Module: (string) (len=11) "__builtin__",
     Name: (string) (len=3) "str"
    },
    Args: (ogórek.Tuple) (len=1 cap=1) {
     (string) (len=14) "188.2.2.2"
    }
   }
  }
 }
```